### PR TITLE
Too much output when used with watchify

### DIFF
--- a/src/tslintify.ts
+++ b/src/tslintify.ts
@@ -15,14 +15,15 @@ export = (b: BrowserifyObject, options) => {
     const tsConfigFile = findConfigFile(projectDir, sys.fileExists);
     const parsed = parseConfigFileTextToJson(tsConfigFile, readFileSync(tsConfigFile, 'UTF-8'));
     const extensions = getSupportedExtensions(parsed.config.compilerOptions) || [];
-    const linter = new Linter({
-        fix: !!options.fix,
-        formatter: options.t || options.format || 'prose',
-        formattersDirectory: options.s || options['formatters-dir'],
-        rulesDirectory: options.r || options['rules-dir'],
-    });
 
     b.transform((file: InputFile) => {
+        const linter = new Linter({
+            fix: !!options.fix,
+            formatter: options.t || options.format || 'prose',
+            formattersDirectory: options.s || options['formatters-dir'],
+            rulesDirectory: options.r || options['rules-dir'],
+        });
+        
         if (
             typeof file !== 'string' ||
             file.lastIndexOf('.') === -1 ||


### PR DESCRIPTION
# Symptoms
Today, I tried to integrate tslintify with browserify and watchify. I noticed that with every file I changed, I would get tslint output for *every* file in my project, not just the changed file. I also noticed that when I fix an issue reported by tslint, after tslint had ran the issue was still being logged.

# Analysis
I dug into the source code of tslintify and tslint, and I noticed that a [`Linter`](https://github.com/palantir/tslint/blob/4.5.1/src/linter.ts) instance ["can lint multiple files in consecutive runs"](https://github.com/palantir/tslint/blob/4.5.1/src/linter.ts#L44). Indeed, the output (an array of `RuleFailure` objects) is kept [as an instance variable](https://github.com/palantir/tslint/blob/4.5.1/src/linter.ts#L44), and [concatenated with new results](https://github.com/palantir/tslint/blob/4.5.1/src/linter.ts#L138) every time you invoke the `lint(...)` method. So when you invoke [`getResult()`](https://github.com/palantir/tslint/blob/4.5.1/src/linter.ts#L141), you do not only get the results of the last `lint(...)` invocations but also of any previous invocations.

# Proposal for fix
I propose to fix this by re-creating the `Linter` instance *inside* the transformation. In this way, every invocation of tslintify will have its own `Linter` instance, which does not keep the previous linting results. Now, if you run tslintify together with browserify and watchify, you'll get *all* linting issues the first time, and then if you change one file you'll only get the linting issues of that file. Also, if you fix an issue, it is no longer being reported.